### PR TITLE
feat: add brute force protection, save login attempts and temporarily blocks user in multiple failed attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ We based this file in [*Keep a Changelog*](https://keepachangelog.com/en/1.0.0/)
 
 ## Added
 
-- Loggin attempts now are saved when user is authenticated by login function;
-- Login function now has brute force protection;
+- Login attempts now are saved when user is authenticated by login function;
+- Login function now checks for multiple failed attempts and blocks user temporarily if necessary;
+- Login function now checks for brute force attempts;
+- Disabled or temporarily blocked user can't be authenticated anymore;
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ We based this file in [*Keep a Changelog*](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## Added
+
+- Loggin attempts now are saved when user is authenticated by login function;
+- Login function now has brute force protection;
+
 ## Changed
 
 - Improve on documentations and validation schemas;

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ config :auth_shield, AuthShield.Repo,
   hostname: "localhost",
   port: 5432
 
-# You can set the session expiration and block attempts by changing this config
-# The default expiration is 15 minutes (in seconds)
-# The default max attempts before block is 10
-# The default block time is 30 minutes
+# You can set the session expiration and block attempts by changing this config.
+# All timestamps are in seconds.
 config :auth_shield, AuthShield,
   session_expiration: 60 * 15,
-  block_attempts: 10,
-  block_time: 60 * 15
+  max_login_attempts: 10,
+  login_block_time: 60 * 15,
+  brute_force_login_interval: 1,
+  brute_force_login_attempts: 3
 ```
 
 In your `test.exs` use the configuration bellow to run it in sandbox mode:
@@ -103,6 +103,8 @@ conn
 |> put_status(200)
 ```
 
+If you are using phoenix we recomend you to check out our utilities doc [here](https://github.com/lcpojr/auth_shield/blob/master/docs/utilities.md).
+
 ## Documentation
 
 You can check out the documentation [here](https://hexdocs.pm/auth_shield/AuthShield.html).
@@ -114,3 +116,4 @@ To know more about how we store the data and the authentication / authorization 
 - [Authentication architecture](https://github.com/lcpojr/auth_shield/blob/master/docs/authentication.md);
 - [Authorization architecture](https://github.com/lcpojr/auth_shield/blob/master/docs/authorization.md);
 - [Database architecture](https://github.com/lcpojr/auth_shield/blob/master/docs/database.md);
+- [Utilities](https://github.com/lcpojr/auth_shield/blob/master/docs/utilities.md);

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,12 +15,12 @@ config :auth_shield, AuthShield.Repo,
   port: 5432
 
 # You can set the session expiration and block attempts by changing this config
-# The default expiration is 15 minutes (in seconds)
-# The default max attempts before block is 10
-# The default block time is 30 minutes
+# All timestamps are in seconds.
 config :auth_shield, AuthShield,
   session_expiration: 60 * 15,
-  block_attempts: 10,
-  block_time: 60 * 15
+  max_login_attempts: 10,
+  login_block_time: 60 * 15,
+  brute_force_login_interval: 1,
+  brute_force_login_attempts: 5
 
 import_config "#{Mix.env()}.exs"

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,0 +1,57 @@
+# Utilities
+
+If you are using phoenix `AuthShield` you can use our plug and validations in order to
+provide authentication to your endpoints.
+
+## Forms
+
+If you are using Phonenix HTML forms you can just use our login and signup schema to build it.
+On your controller use:
+
+```elixir
+    render(conn, "login.html", form_changeset: AuthShield.Validations.Login())
+```
+
+After that you can just pass it throw your templates:
+
+```elixir
+    <%= form_for @form_changeset, Routes.page_path(@conn, :login), fn f -> %>
+        <div class="form-group">
+            <%= label f, :email, class: "control-label" %>
+            <%= email_input f, :email %>
+            <%= error_tag f, :email %>
+        </div>
+        <div class="form-group">
+            <%= label f, :password, class: "control-label" %>
+            <%= password_input f, :password %>
+            <%= error_tag f, :password %>
+        </div>
+
+        <%= submit "Submit" %>
+    <% end %>
+```
+
+You can do just the same for `AuthShield.Validations.SignUp`.
+
+## Plugs
+
+If you has an endpoint that you need to be authenticate and don't wan't
+to handle with it by calling all authentication functions you can use
+the session plug to get do it and just declare a fallback:
+
+In your router add it:
+
+```elixir
+    pipeline :authenticated do
+        plug(AuthShield.Authentication.Plugs.AuthSession)
+    end
+
+    scope "/profile/change-password" do
+        pipe_through(:authenticated)
+        get("/", ProfilesController, :change_password)
+        post("/", ProfilesController, :change_password)
+    end
+```
+
+If someone tries to access these endpoints without has an active session the plug
+will return `{:error, :unauthenticated}`.

--- a/lib/auth_shield/authentication.ex
+++ b/lib/auth_shield/authentication.ex
@@ -38,7 +38,7 @@ defmodule AuthShield.Authentication do
 
   defdelegate list_login_attempt(filters), to: LoginAttempts, as: :list
 
-  defdelegate list_failure_login_attempts(user_id, from_date),
+  defdelegate list_failure_login_attempts(user, from_date),
     to: LoginAttempts,
     as: :list_failure
 

--- a/lib/auth_shield/authentication/login_attempts.ex
+++ b/lib/auth_shield/authentication/login_attempts.ex
@@ -9,8 +9,8 @@ defmodule AuthShield.Authentication.LoginAttempts do
   require Ecto.Query
 
   alias AuthShield.Authentication.Schemas.LoginAttempt
-  alias AuthShield.Resources.Schemas.User
   alias AuthShield.Repo
+  alias AuthShield.Resources.Schemas.User
 
   @typedoc "Transactional responses of success"
   @type success_response :: {:ok, LoginAttempt.t()}

--- a/lib/auth_shield/authentication/login_attempts.ex
+++ b/lib/auth_shield/authentication/login_attempts.ex
@@ -9,6 +9,7 @@ defmodule AuthShield.Authentication.LoginAttempts do
   require Ecto.Query
 
   alias AuthShield.Authentication.Schemas.LoginAttempt
+  alias AuthShield.Resources.Schemas.User
   alias AuthShield.Repo
 
   @typedoc "Transactional responses of success"
@@ -92,22 +93,15 @@ defmodule AuthShield.Authentication.LoginAttempts do
 
   ## Exemples:
     ```elixir
-    AuthShield.Authentication.LoginAttempts.list_failure(
-      "ecb4c67d-6380-4984-ae04-1563e885d59e",
-      ~N[2000-01-01 23:00:07]
-    )
+    AuthShield.Authentication.LoginAttempts.list_failure(user, ~N[2000-01-01 23:00:07])
     ```
   """
-  @spec list_failure(
-          user_id :: String.t(),
-          from_date :: NaiveDateTime.t()
-        ) :: list(LoginAttempt.t())
-  def list_failure(user_id, from_date) when is_binary(user_id) do
+  @spec list_failure(user :: User.t(), from_date :: NaiveDateTime.t()) :: list(LoginAttempt.t())
+  def list_failure(%User{} = user, from_date) do
     LoginAttempt
-    |> Ecto.Query.where(
-      [a],
-      a.user_id == ^user_id and a.status == "failed" and a.inserted_at >= ^from_date
-    )
+    |> Ecto.Query.where([a], a.user_id == ^user.id)
+    |> Ecto.Query.where([a], a.status == "failed" and a.inserted_at >= ^from_date)
+    |> Ecto.Query.order_by(desc: :inserted_at)
     |> Repo.all()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -79,7 +79,13 @@ defmodule AuthShield.MixProject do
   defp docs do
     [
       main: "AuthShield",
-      extras: ["README.md", "docs/database.md", "docs/authentication.md", "docs/authorization.md"],
+      extras: [
+        "README.md",
+        "docs/database.md",
+        "docs/authentication.md",
+        "docs/authorization.md",
+        "docs/utilities.md"
+      ],
       deps: [
         ecto_sql: "https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.html",
         argon2_elixir: "https://hexdocs.pm/argon2_elixir/api-reference.html",

--- a/test/auth_shield/authentication/login_attempts_test.exs
+++ b/test/auth_shield/authentication/login_attempts_test.exs
@@ -90,7 +90,7 @@ defmodule AuthShield.Authentication.LoginAttemptsTest do
     test "return a list of login_attempts", ctx do
       assert from_date = NaiveDateTime.add(NaiveDateTime.utc_now(), -(60 * 15), :second)
       assert ids = Enum.map(ctx.login_attempts, & &1.id)
-      assert login_attempts = LoginAttempts.list_failure(ctx.user.id, from_date)
+      assert login_attempts = LoginAttempts.list_failure(ctx.user, from_date)
       assert Enum.all?(login_attempts, &(&1.id in ids))
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -22,7 +22,8 @@ defmodule AuthShield.Factory do
       user_id: Ecto.UUID.generate(),
       remote_ip: sequence(:session_remote_ip, &"172.31.4.#{&1}"),
       user_agent: "Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0",
-      status: "succeed"
+      status: "succeed",
+      inserted_at: NaiveDateTime.utc_now()
     }
   end
 


### PR DESCRIPTION
This PR has multiple changes on login flow.

- Login attempts now are saved when user is authenticated by login function;
- Login function now checks for multiple failed attempts and blocks user temporarily if necessary;
- Login function now checks for brute force attempts;
- Disabled or temporarily blocked user can't be authenticated anymore;